### PR TITLE
Renames Type to StateType

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     siteUrl = 'https://github.com/fluentio'
     gitUrl = 'https://github.com/fluentio/Fluent.git'
 
-    libraryVersion = '0.1.2'
+    libraryVersion = '0.2.0'
 
     developerId = properties.getProperty("user.id")
     developerName = properties.getProperty("user.name")

--- a/library/src/main/kotlin/io/fluent/State.kt
+++ b/library/src/main/kotlin/io/fluent/State.kt
@@ -1,5 +1,5 @@
 package io.fluent
 
 interface State {
-  fun type(): Type
+  fun type(): StateType
 }

--- a/library/src/main/kotlin/io/fluent/StateType.kt
+++ b/library/src/main/kotlin/io/fluent/StateType.kt
@@ -1,0 +1,8 @@
+package io.fluent
+
+open class StateType {
+  object Initial : StateType()
+  object Loading : StateType()
+  object Success : StateType()
+  object Error : StateType()
+}

--- a/library/src/main/kotlin/io/fluent/Type.kt
+++ b/library/src/main/kotlin/io/fluent/Type.kt
@@ -1,8 +1,0 @@
-package io.fluent
-
-open class Type {
-  object Initial : Type()
-  object Loading : Type()
-  object Success : Type()
-  object Error : Type()
-}


### PR DESCRIPTION
Currently, the class `Type` represents a type of a state. 

This PR renames it to `StateType` to improve readability 